### PR TITLE
Exclude gitlab env variable in helm upgrade

### DIFF
--- a/deploy-helm
+++ b/deploy-helm
@@ -65,7 +65,7 @@ if [[ "$DEPLOYMENT_MANIFEST" ]]; then
   # we convert __ back to . as dot is not allowed for environment variable names.
   # we also need to quote the variables that has = in the value.
   # And in the end, join them with comma as specified in helm --set parameter
-  ENV_VARS=$(echo "" | awk 'BEGIN {ORS=","}; {split("CI_BUILD_TOKEN CI_REGISTRY_PASSWORD CI_REGISTRY_USER DEPLOYMENT_KEY PRIVATE_TOKEN CI_COMMIT_TITLE CI_COMMIT_MESSAGE CI_COMMIT_DESCRIPTION", va); for (i in va) excluded[va[i]];  for (i in ENVIRON) { if (i in excluded) { continue;  }; c=i; gsub("__", ".", c); if (index(ENVIRON[i], "=")) { v = "'\''"ENVIRON[i]"'\''"  } else { v = ENVIRON[i]  };  print c "=" v  }}')
+  ENV_VARS=$(echo "" | awk 'BEGIN {ORS=","}; {split("CI_BUILD_TOKEN CI_REGISTRY_PASSWORD CI_REGISTRY_USER DEPLOYMENT_KEY PRIVATE_TOKEN CI_COMMIT_TITLE CI_COMMIT_MESSAGE CI_COMMIT_DESCRIPTION CI_PROJECT_REPOSITORY_LANGUAGES", va); for (i in va) excluded[va[i]];  for (i in ENVIRON) { if (i in excluded) { continue;  }; c=i; gsub("__", ".", c); if (index(ENVIRON[i], "=")) { v = "'\''"ENVIRON[i]"'\''"  } else { v = ENVIRON[i]  };  print c "=" v  }}')
 
   if [[ "$DEBUG" ]]; then
     echo $ENV_VARS


### PR DESCRIPTION
- gitlab 12.3 added a new env variable CI_PROJECT_REPOSITORY_LANGUAGES. It
contains comma separated values and will confuse `helm upgrade` if
included as `--set` parameter.  Excluding this env variable from the
`helm upgrade` command